### PR TITLE
Implemented message source to get messages from messages.properties and MessageCode enum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 				<version>${maven-surefire-plugin.version}</version>
 				<configuration>
 					<includes>
-						<!--						cucumber runners-->
+						<include>pl.taskyers.taskybase.core.CucumberRunnerCore</include>
 					</includes>
 				</configuration>
 			</plugin>

--- a/src/main/java/pl/taskyers/taskybase/core/configuration/MessageSourceConfiguration.java
+++ b/src/main/java/pl/taskyers/taskybase/core/configuration/MessageSourceConfiguration.java
@@ -1,0 +1,21 @@
+package pl.taskyers.taskybase.core.configuration;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import pl.taskyers.taskybase.core.message.MessageCode;
+
+@Configuration
+public class MessageSourceConfiguration {
+    
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        MessageCode.setMessageSource(messageSource);
+        return messageSource;
+    }
+    
+}

--- a/src/main/java/pl/taskyers/taskybase/core/message/MessageCode.java
+++ b/src/main/java/pl/taskyers/taskybase/core/message/MessageCode.java
@@ -1,0 +1,41 @@
+package pl.taskyers.taskybase.core.message;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.NoSuchMessageException;
+
+import java.util.Locale;
+
+@Slf4j
+public enum MessageCode {
+    
+    /**
+     * Only for test purposes - do not change it
+     **/
+    test,
+    test_1,
+    test_1_2,
+    test_1_2_3,
+    test_1_2_3_4;
+    
+    private static MessageSource messageSource;
+    
+    public static void setMessageSource(MessageSource messageSource) {
+        MessageCode.messageSource = messageSource;
+    }
+    
+    public String getMessage(Object... args) {
+        String message = replaceUnderscores(this.toString());
+        try {
+            return messageSource.getMessage(message, args, Locale.US);
+        } catch ( NoSuchMessageException e ) {
+            log.warn("Message with code: " + this.toString() + " (" + message + ") was not found");
+            return null;
+        }
+    }
+    
+    private String replaceUnderscores(String message) {
+        return message.replace("_", ".");
+    }
+    
+}

--- a/src/test/java/pl/taskyers/taskybase/core/CucumberRunnerCore.java
+++ b/src/test/java/pl/taskyers/taskybase/core/CucumberRunnerCore.java
@@ -1,0 +1,11 @@
+package pl.taskyers.taskybase.core;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(plugin = { "pretty", "junit:target/cucumber/cucumber_core.xml",
+        "json:target/cucumber/cucumber_core.json" }, features = "src/test/resources/pl/taskyers/taskybase/core/")
+public class CucumberRunnerCore {
+}

--- a/src/test/java/pl/taskyers/taskybase/core/MessageCodeProvider.java
+++ b/src/test/java/pl/taskyers/taskybase/core/MessageCodeProvider.java
@@ -1,0 +1,15 @@
+package pl.taskyers.taskybase.core;
+
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import pl.taskyers.taskybase.core.message.MessageCode;
+
+public class MessageCodeProvider {
+    
+    public static void setMessageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        MessageCode.setMessageSource(messageSource);
+    }
+    
+}

--- a/src/test/java/pl/taskyers/taskybase/core/message/MessageCodeStepdefs.java
+++ b/src/test/java/pl/taskyers/taskybase/core/message/MessageCodeStepdefs.java
@@ -1,0 +1,73 @@
+package pl.taskyers.taskybase.core.message;
+
+import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import org.springframework.context.annotation.PropertySource;
+import pl.taskyers.taskybase.core.MessageCodeProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@PropertySource("classpath:messages.properties")
+public class MessageCodeStepdefs {
+    
+    private MessageCode entry;
+    
+    private List<Object> arguments = new ArrayList<>();
+    
+    private String result;
+    
+    @Before
+    public void setUp() {
+        MessageCodeProvider.setMessageSource();
+    }
+    
+    @Given("^Message code \"([^\"]*)\"$")
+    public void messageCode(String code) {
+        entry = MessageCode.valueOf(code);
+    }
+    
+    @And("^There are no arguments$")
+    public void thereAreNoArguments() {
+        arguments = null;
+    }
+    
+    @And("^\"([^\"]*)\" argument is \"([^\"]*)\"$")
+    public void firstArgumentIs(String number, String firstArg) {
+        arguments.add(firstArg);
+    }
+    
+    @When("^I get message from message source$")
+    public void iGetMessageFromMessageSource() throws Exception {
+        if ( convertArguments(arguments) != null ) {
+            result = entry.getMessage(convertArguments(arguments));
+        } else {
+            result = entry.getMessage();
+        }
+    }
+    
+    @Then("^Message is \"([^\"]*)\"$")
+    public void messageIs(String expected) {
+        assertEquals(expected, result);
+    }
+    
+    @Then("^Message is null$")
+    public void messageIsNull() {
+        assertNull(result);
+    }
+    
+    private Object[] convertArguments(List<Object> arguments) {
+        if ( arguments != null ) {
+            Object[] argumentsArray = new Object[arguments.size()];
+            return arguments.toArray(argumentsArray);
+        }
+        return null;
+    }
+    
+}

--- a/src/test/resources/messages.properties
+++ b/src/test/resources/messages.properties
@@ -1,0 +1,4 @@
+test=test
+test.1=test {0}
+test.1.2=test {0} {1}
+test.1.2.3=test {0} {1} {2}

--- a/src/test/resources/pl/taskyers/taskybase/core/message/message_code.feature
+++ b/src/test/resources/pl/taskyers/taskybase/core/message/message_code.feature
@@ -1,0 +1,37 @@
+Feature: Getting messages from message source and MessageCode enum
+
+  Scenario: Getting message without arguments
+    Given Message code "test"
+    And There are no arguments
+    When I get message from message source
+    Then Message is "test"
+
+  Scenario: Getting message with one argument
+    Given Message code "test_1"
+    And "First" argument is "firstArgument"
+    When I get message from message source
+    Then Message is "test firstArgument"
+
+  Scenario: Getting message with two arguments
+    Given Message code "test_1_2"
+    And "First" argument is "firstArgument"
+    And "Second" argument is "secondArgument"
+    When I get message from message source
+    Then Message is "test firstArgument secondArgument"
+
+  Scenario: Getting message with three arguments
+    Given Message code "test_1_2_3"
+    And "First" argument is "firstArgument"
+    And "Second" argument is "secondArgument"
+    And "Third" argument is "thirdArgument"
+    When I get message from message source
+    Then Message is "test firstArgument secondArgument thirdArgument"
+
+  Scenario: Getting message when message not exists in message.properties but exists in enum
+    Given Message code "test_1_2_3_4"
+    And "First" argument is "firstArgument"
+    And "Second" argument is "secondArgument"
+    And "Third" argument is "thirdArgument"
+    And "Fourth" argument is "fourthArgument"
+    When I get message from message source
+    Then Message is null


### PR DESCRIPTION
How to use messages from messages.properties:
1. Add message name with dots (e.g. test.1.2.3) in messages.properties
2. Add message code with underscores (e.g. test_1_2_3) in MessageCode enum
3. Call getMessage(arguments) method on enum const (e.g. MessageCode.test_1_2_3.getMessage(arg1, arg2, arg3)

If you want to use MessageCode in tests you need to call in setUp method MessageCodeProvider.setMessageSource()